### PR TITLE
Update account_menuitem.xml

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -9,8 +9,8 @@
             web_icon="account,static/description/icon.png"
             sequence="40"/>
 
-        <menuitem id="menu_finance_receivables" name="Customers" parent="menu_finance" sequence="2"/>
-        <menuitem id="menu_finance_payables" name="Vendors" parent="menu_finance" sequence="3"/>
+        <menuitem id="menu_finance_receivables" name="Sales" parent="menu_finance" sequence="2"/>
+        <menuitem id="menu_finance_payables" name="Purchases" parent="menu_finance" sequence="3"/>
         <menuitem id="menu_finance_entries" name="Accounting" parent="menu_finance" sequence="4" groups="account.group_account_user"/>
             <!-- Adviser sub-menus -->
             <menuitem id="menu_finance_entries_accounting_entries" name="Accounting Entries" parent="account.menu_finance_entries"/>


### PR DESCRIPTION
Renamed menu_finance_receivables and menu_finance_payables to Sales and Purchases. It is referenced like so in the po files, and actually, the terms "Customers" and "Providers" in those menu items lead to error.

Description of the issue/feature this PR addresses:

Current behavior before PR:
Top level Menu items in accounting "Customers" and "Providers" lead to error, and in fact, in the po files "Sales" and "Purchases" are expected.

Desired behavior after PR is merged:
Display the menu item names correctly



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
